### PR TITLE
Update repo and new example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Continue reading the public webpage content of this repository here:
 
 * [sysdiglabs.github.io/secure-inline-scan-examples](https://sysdiglabs.github.io/secure-inline-scan-examples)
 
-It is not a comprehensive catalog of _examples_ for all integrations available, but a live document where we continually publish more information as we see users need it. We do try to keep a list of links to all integrations and toher related websites that you may find useful.
+It is not a comprehensive catalog of _examples_ for all integrations available, but a live document where we continually publish more information as we see users need it. We do try to keep a list of links to all integrations and other related websites that you may find useful.
 
 ## Issues and pull requests
 
-If you find a related topic lacks enough information, or some problem with any of the existing examples, please file a issue in this repository. Pull requests to ammend any existing information or examples are also welcomed.
+If you find a related topic lacks enough information, or some problem with any of the existing examples, please file a issue in this repository. Pull requests to amend any existing information or examples are also welcomed.
 
 ## More information
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 title: Sysdig Secure Inline Scan Examples
 summary: >
   This is not a comprehensive catalog of examples for all integrations available, but a live document where we continually publish more information as we see users need it.
-  We do try to keep a list of links to all integrations and toher related websites that you may find useful.
+  We do try to keep a list of links to all integrations and other related websites that you may find useful.
 ---
 
 # Examples
@@ -11,8 +11,9 @@ In this [repository](https://github.com/sysdiglabs/secure-inline-scan-examples/)
 
 * [Google Cloud Build](https://github.com/sysdiglabs/secure-inline-scan-examples/tree/main/google-cloud-build)
 * Jenkins
-  * [Build and scan](https://github.com/sysdiglabs/secure-inline-scan-examples/tree/main/jenkins/jenkins-build-and-scan)
   * [Scan from repository](https://github.com/sysdiglabs/secure-inline-scan-examples/tree/main/jenkins/jenkins-scan-from-repo)
+  * [Build and scan](https://github.com/sysdiglabs/secure-inline-scan-examples/tree/main/jenkins/jenkins-build-push-scan-from-repo)
+  * [Build, push and scan from repository](https://github.com/sysdiglabs/secure-inline-scan-examples/tree/main/jenkins/jenkins-build-and-scan)
 * [Tekton](https://github.com/sysdiglabs/secure-inline-scan-examples/tree/main/tekton)
   * [Tekton alpha API](https://github.com/sysdiglabs/secure-inline-scan-examples/tree/main/tekton/alpha)
   * [Tekton beta API](https://github.com/sysdiglabs/secure-inline-scan-examples/tree/main/tekton/beta)

--- a/jenkins/jenkins-build-push-scan-from-repo/Jenkinsfile
+++ b/jenkins/jenkins-build-push-scan-from-repo/Jenkinsfile
@@ -1,0 +1,83 @@
+pipeline {
+    agent {
+        kubernetes {
+            yaml """
+apiVersion: v1 
+kind: Pod 
+metadata: 
+    name: inline-scan-worker
+spec: 
+    containers: 
+      - name: jnlp
+      - name: maven
+        image: maven:3.6-jdk-11
+        command: ['cat']
+        tty: true
+      - name: builder
+        image: gcr.io/kaniko-project/executor:debug
+        command: ['cat']
+        tty: true
+      - name: inline-scan
+        image: quay.io/sysdig/secure-inline-scan:2
+        command: ['cat']
+        tty: true
+"""
+       }
+   }
+
+    parameters { 
+        string(name: 'IMAGE_NAME', defaultValue: 'docker.io/sysdiglabs/test-maven-app', description: 'Name of the image to be built andscanned (e.g.: myrepo/dummy-app)') 
+    }
+    
+    environment {
+        DOCKER = credentials('docker-repository-credentials')
+        SECURE_API_KEY = credentials('sysdig-secure-api-credentials')
+    }
+    
+    stages {
+        stage('Checkout') {
+            steps {
+                git 'https://github.com/openshift/test-maven-app'
+            }
+        }
+        stage('Build app') {
+            steps {
+                container("maven") {
+                    sh "mvn package"
+                }
+            }
+        }
+        stage('Build image and push') {
+            steps {
+                container("builder") {
+                    sh """cat > config.json <<EOF
+{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "\$(echo -n \${DOCKER} | base64)"
+		}
+	}
+}
+EOF
+                    """
+                    sh "cat config.json"
+                    sh """cat > Dockerfile <<EOF
+FROM gcr.io/distroless/java:11
+COPY target/hello.jar /hello.jar
+CMD /hello.jar
+EOF
+                    """
+                    sh "/kaniko/executor --context . --verbosity debug --destination ${IMAGE_NAME}"
+
+                }
+            }
+        }
+        stage('Scanning Image pulled from repository') {
+            steps {
+                container("inline-scan") {
+                    sh "/sysdig-inline-scan.sh -k ${SECURE_API_KEY_PSW} ${IMAGE_NAME}"
+                }
+            }
+        }
+   }
+}

--- a/jenkins/jenkins-scan-from-repo/Jenkinsfile
+++ b/jenkins/jenkins-scan-from-repo/Jenkinsfile
@@ -9,14 +9,6 @@ metadata:
 spec: 
     containers: 
       - name: jnlp
-      - name: maven
-        image: maven:3.6-jdk-11
-        command: ['cat']
-        tty: true
-      - name: builder
-        image: gcr.io/kaniko-project/executor:debug
-        command: ['cat']
-        tty: true
       - name: inline-scan
         image: sysdiglabs/secure-inline-scan:2
         command: ['cat']
@@ -26,52 +18,14 @@ spec:
    }
 
     parameters { 
-        string(name: 'IMAGE_NAME', defaultValue: 'docker.io/sysdiglabs/test-maven-app', description: 'Name of the image to be built andscanned (e.g.: myrepo/dummy-app)') 
+        string(name: 'IMAGE_NAME', defaultValue: 'sysdiglabs/dummy-vuln-app', description: 'Name of the image to be built andscanned (e.g.: myrepo/dummy-app)') 
     }
     
     environment {
-        DOCKER = credentials('docker-repository-credentials')
         SECURE_API_KEY = credentials('sysdig-secure-api-credentials')
     }
     
     stages {
-        stage('Checkout') {
-            steps {
-                git 'https://github.com/openshift/test-maven-app'
-            }
-        }
-        stage('Build app') {
-            steps {
-                container("maven") {
-                    sh "mvn package"
-                }
-            }
-        }
-        stage('Build image and push') {
-            steps {
-                container("builder") {
-                    sh """cat > config.json <<EOF
-{
-	"auths": {
-		"https://index.docker.io/v1/": {
-			"auth": "\$(echo -n \${DOCKER} | base64)"
-		}
-	}
-}
-EOF
-                    """
-                    sh "cat config.json"
-                    sh """cat > Dockerfile <<EOF
-FROM gcr.io/distroless/java:11
-COPY target/hello.jar /hello.jar
-CMD /hello.jar
-EOF
-                    """
-                    sh "/kaniko/executor --context . --verbosity debug --destination ${IMAGE_NAME}"
-
-                }
-            }
-        }
         stage('Scanning Image pulled from repository') {
             steps {
                 container("inline-scan") {

--- a/unprivileged-docker/localbuild_scan.sh
+++ b/unprivileged-docker/localbuild_scan.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# v2: Updated to use sysdiglabs/secure-inline-scan:2
+# v2: Updated to use quay.io/sysdig/secure-inline-scan:2
 
 # This is an example pipeline execution as a Bash script of how to
 # execute an inline scan with Sysdig without requiring priviledges.
@@ -52,7 +52,7 @@ function scan {
     echo
     echo "> Scan"
 
-    docker run -v $PWD:/workspace sysdiglabs/secure-inline-scan:2 \
+    docker run -v $PWD:/workspace quay.io/sysdig/secure-inline-scan:2 \
         -s https://secure.sysdig.com \
         --storage-type oci-dir \
         --storage-path /workspace/oci \

--- a/unprivileged-docker/registry_scan.sh
+++ b/unprivileged-docker/registry_scan.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Uses sysdiglabs/secure-inline-scan:2
+# Uses quay.io/sysdig/secure-inline-scan:2
 
 # This is an example script that scans from a private registry
 # with Sysdig without requiring priviledges.
@@ -50,7 +50,7 @@ function scan {
 
     docker run \
         -v $PWD:/workspace \
-        sysdiglabs/secure-inline-scan:2 \
+        quay.io/sysdig/secure-inline-scan:2 \
         --registry-auth-file /workspace/docker-config.json \
         -k $SYSDIG_SECURE_API_TOKEN \
         -s https://secure.sysdig.com \


### PR DESCRIPTION
* Update repo to use quay.io/sysdig/secure-inline-scan:2
* Add a simpler Jenkins example to scan from repo, instead of build, push and scan (keep that as a different example)