### PR TITLE
Update links, cleanup whitespaces and update image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Sysdig Secure Inline Scan Examples
 
-This repository contains examples and information about **how to use** [Sysdig Secure inline scan](https://github.com/sysdiglabs/secure-inline-scan) in different integrations and use case scenarios.
+This repository contains examples and information about **how to use** [Sysdig Secure inline scan](https://docs.sysdig.com/en/integrate-with-ci-cd-tools.html) in different integrations and use case scenarios.
 
 Continue reading the public webpage content of this repository here:
 
 * [sysdiglabs.github.io/secure-inline-scan-examples](https://sysdiglabs.github.io/secure-inline-scan-examples)
 
-It is not a comprehensive catalog of _examples_ for all integrations available, but a live document where we continually publish more information as we see users need it. We do try to keep a list of links to all integrations and other related websites that you may find useful.
+It is not a comprehensive _example_ catalog for every available integration, but a live document where we continually publish more information as we see users need it. We try to keep a list of links to all integrations and other convenient and related websites.
 
 ## Issues and pull requests
 
-If you find a related topic lacks enough information, or some problem with any of the existing examples, please file a issue in this repository. Pull requests to amend any existing information or examples are also welcomed.
+If you find a related topic that lacks enough information or some problem with any of the existing examples, please file an issue in this repository. Pull requests to amend any existing information or examples are also welcome.
 
 ## More information
 
 * Sysdig.com
 * [Sysdig Documentation website - Image Scanning](https://docs.sysdig.com/en/image-scanning.html)
-* [Sysdig Secure inline scan repository](https://github.com/sysdiglabs/secure-inline-scan)
+* [Image Scanning - Integrate with CI/CD Tools](https://docs.sysdig.com/en/integrate-with-ci-cd-tools.html)
 

--- a/deprecated-jenkins-inline-scan-v1/Jenkinsfile
+++ b/deprecated-jenkins-inline-scan-v1/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline{
                         script {
                             sh "docker pull ${IMAGE_NAME}"
                         }
-                        
+
                     }
                 }
             }

--- a/docs/index.md
+++ b/docs/index.md
@@ -158,9 +158,9 @@ These integrations have a specific entry in their respective CI/CD catalogs:
 
 Official documentation pages must be current to the features provided by the inline scanner, but their explanations may be brief:
 
-* [Registry Scanning](https://sysdig.com/products/kubernetes-security/image-scanning/) (main Sysdig web page)
+* [CI/CD and Registry Scanning with Runtime Vulnerability Reporting](https://sysdig.com/products/secure/image-scanning/) (main Sysdig web page)
 * [Image Scanning](https://docs.sysdig.com/en/image-scanning.html) (Sysdig Documentation website)
-* [Sysdig Secure inline scan repository](https://github.com/sysdiglabs/secure-inline-scan) (main project code repository's readme)
+* [Image Scanning - Integrate with CI/CD Tools](https://docs.sysdig.com/en/integrate-with-ci-cd-tools.html)
 
 ## Blog articles
 

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,67 @@
+# Inline Scan in Jenkins
+
+## Sysdig Secure Jenkins plugin
+
+The [Sysdig Secure Jenkins plugin](https://plugins.jenkins.io/sysdig-secure/) can be used in a Pipeline job, or added as a build step to a Freestyle job to automate the process of running an image analysis, evaluating custom policies against images, and performing security scans.
+
+The plugin supports both backend and inline scanning and scan result integration. It publishes the scan report as part of the Jenkins job results, directly available from the UI.
+
+However, the current version requires a working Docker environment (Docker socket must be available) for inline scanning. This requirement doesn't fit all scenarios, like running the Jenkins worker as a Pod when using the Kubernetes plugin, unless you use [Docker-in-Docker, which is discouraged](https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/).
+
+See more information at the plugin page: https://plugins.jenkins.io/sysdig-secure/
+
+## Using the Kubernetes plugin (podTemplate)
+
+The inline scanner runs as a container `quay.io/sysdig/secure-inline-scan:2`, but it does not depend on the Docker socket being available (except for scanning local Docker images). So the inline scan container can be executed as part of a [Kubernetes plugin](https://plugins.jenkins.io/kubernetes/) podTemplate.
+
+The following pipelines show different usage examples. All they have in common is the `quay.io/sysdig/secure-inline:2` container is added as an additional container inside the podTemplate executing the Jenkins worker. The container entrypoint is changed to `cat` so the container is started in a "paused" state. At some point in the pipeline, the `/sysdig-inline-scan.sh` script (the original entrypoint)  is executed inside the inline-scan container.
+
+  * [Scan from repository](jenkins-scan-from-repo/)
+  * [Build and scan](jenkins-build-and-scan/)
+  * [Build, push and scan from repository](jenkins-build-push-scan-from-repo/)
+  * [Build, push and scan using Openshift internal registry](jenkins-openshift-internal-registry/)
+
+### Troubleshooting
+
+#### Execution of `/sysdig-inline-scan.sh` getting stuck 
+
+In case the execution of the:
+
+```
+                container("inline-scan") {
+                    sh "/sysdig-inline-scan.sh -k ${SECURE_API_KEY_PSW} ${IMAGE_NAME}"
+                }
+```
+
+is stuck for a while, and then finishes with:
+
+```
+...
+process apparently never started in /tmp/workspace/test-sysdig-inline-scan@tmp/durable-c48f0134
+(running Jenkins temporarily with -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true might make the problem clearer)
+```
+
+you can enable launch diagnostics as described in the error message to get further information. You might find one of the following problems.
+
+**UID mismatch**
+
+Described in the [Kubernetes plugin page](https://plugins.jenkins.io/kubernetes/):
+
+> this problem usually happens when the UID of the user in the JNLP container differs from the one in other container(s). All containers you use should have the same UID of the user, also this can be achieved by setting *securityContext*
+
+For example, if the *jnlp* container runs as UID 1001, and the inline-scan container runs with the default UID 1000, the `sh` step will fail due to permissions when writing the output:
+
+```
+sh: can't create /home/jenkins/agent/workspace/thejob@tmp/durable-e0b7cd27/jenkins-log.txt: Permission denied
+sh: can't create /home/jenkins/agent/workspace/thejob@tmp/durable-e0b7cd27/jenkins-result.txt.tmp: Permission denied
+mv: can't rename '/home/jenkins/agent/workspace/thejob@tmp/durable-e0b7cd27/jenkins-result.txt.tmp': No such file or directory
+touch: /home/jenkins/agent/workspace/thejob@tmp/durable-e0b7cd27/jenkins-log.txt: Permission denied
+touch: /home/jenkins/agent/workspace/thejob@tmp/durable-e0b7cd27/jenkins-log.txt: Permission denied
+touch: /home/jenkins/agent/workspace/thejob@tmp/durable-e0b7cd27/jenkins-log.txt: Permission denied
+```
+
+You can fix it by making all the containers execute using the same UID using the [securityContext parameter](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) in the podTemplate
+
+**Working directory**
+
+If the `workingDir` of the container is not specified, it could be set to an invalid path that causes problems when mounting. Try setting `workingDir: /tmp`.

--- a/jenkins/jenkins-build-and-scan/Jenkinsfile
+++ b/jenkins/jenkins-build-and-scan/Jenkinsfile
@@ -2,12 +2,12 @@ pipeline {
     agent {
         kubernetes {
             yaml """
-apiVersion: v1 
-kind: Pod 
-metadata: 
+apiVersion: v1
+kind: Pod
+metadata:
     name: inline-scan-worker
-spec: 
-    containers: 
+spec:
+    containers:
       - name: jnlp
       - name: maven
         image: maven:3.6-jdk-11
@@ -25,14 +25,14 @@ spec:
        }
    }
 
-    parameters { 
-        string(name: 'IMAGE_NAME', defaultValue: 'docker.io/sysdiglabs/test-maven-app', description: 'Name of the image to be built andscanned (e.g.: myrepo/dummy-app)') 
+    parameters {
+        string(name: 'IMAGE_NAME', defaultValue: 'docker.io/sysdiglabs/test-maven-app', description: 'Name of the image to be built andscanned (e.g.: myrepo/dummy-app)')
     }
-    
+
     environment {
         SECURE_API_KEY = credentials('sysdig-secure-api-credentials')
     }
-    
+
     stages {
         stage('Checkout') {
             steps {

--- a/jenkins/jenkins-build-and-scan/README.md
+++ b/jenkins/jenkins-build-and-scan/README.md
@@ -1,0 +1,11 @@
+# Build and scan example
+
+This [example pipeline](Jenkinsfile) shows how to build, scan and push a Docker image in a dockerless environment, by creating a podTemplate with 4 containers:
+ * **jnlp** container. Required for the Jenkins agent.
+ * **maven** container for building a Java application.
+ * **builder** container, using [Kaniko](https://github.com/GoogleContainerTools/kaniko) to build a Docker image without requiring the Docker daemon. The `--no-push` option tells Kaniko not to push the image to a registry, and just store it locally in the `oci` folder inside the workspace.
+ * **inline-scan** container, where the pipeline executes the `inline-scan.sh` script to analyze the image built in the previous step locally from the `oci` folder in the workspace.
+
+Finally, an optional 5th step could be included to push the image to the registry, if the scan is successful, by using [Skopeo](https://github.com/containers/skopeo).
+
+See [Jenkins examples README.md](../README.md) for common usage tips and troubleshooting.

--- a/jenkins/jenkins-build-push-scan-from-repo/Jenkinsfile
+++ b/jenkins/jenkins-build-push-scan-from-repo/Jenkinsfile
@@ -2,12 +2,12 @@ pipeline {
     agent {
         kubernetes {
             yaml """
-apiVersion: v1 
-kind: Pod 
-metadata: 
+apiVersion: v1
+kind: Pod
+metadata:
     name: inline-scan-worker
-spec: 
-    containers: 
+spec:
+    containers:
       - name: jnlp
       - name: maven
         image: maven:3.6-jdk-11
@@ -25,15 +25,15 @@ spec:
        }
    }
 
-    parameters { 
-        string(name: 'IMAGE_NAME', defaultValue: 'docker.io/sysdiglabs/test-maven-app', description: 'Name of the image to be built andscanned (e.g.: myrepo/dummy-app)') 
+    parameters {
+        string(name: 'IMAGE_NAME', defaultValue: 'docker.io/sysdiglabs/test-maven-app', description: 'Name of the image to be built andscanned (e.g.: myrepo/dummy-app)')
     }
-    
+
     environment {
         DOCKER = credentials('docker-repository-credentials')
         SECURE_API_KEY = credentials('sysdig-secure-api-credentials')
     }
-    
+
     stages {
         stage('Checkout') {
             steps {

--- a/jenkins/jenkins-build-push-scan-from-repo/README.md
+++ b/jenkins/jenkins-build-push-scan-from-repo/README.md
@@ -1,0 +1,9 @@
+# Build, push and scan from repository example
+
+This [example pipeline](Jenkinsfile) shows how to build, push, and then scan the Docker image in a dockerless environment, by creating a podTemplate with 4 containers:
+ * **jnlp** container. Required for the Jenkins agent.
+ * **maven** container for building a Java application.
+ * **builder** container, using [Kaniko](https://github.com/GoogleContainerTools/kaniko) to build a Docker image without requiring the Docker daemon. Once build, the image is pushed to the destination target registry and repository.
+ * **inline-scan** container, where the pipeline executes the `inline-scan.sh` script to analyze the image pushed to the repository in the previous step.
+
+See [Jenkins examples README.md](../README.md) for common usage tips and troubleshooting.

--- a/jenkins/jenkins-openshift-internal-registry/README.md
+++ b/jenkins/jenkins-openshift-internal-registry/README.md
@@ -1,0 +1,18 @@
+# Build, push and scan from Openshift internal registry
+
+This [example pipeline](Jenkinsfile) shows how to build, push, and then scan the Docker image in Openshift, using the service account credentials to push and scan from the Openshift internal registry.
+
+The podTemplate in the example is composed by 4 containers:
+ * **jnlp** container. Required for the Jenkins agent. Also, we mount the service account secret in `/home/jenkins/agent/.dockercfg` to convert the old dockercfg format to the new config.json format required by Kaniko and the Inline Scanner:
+
+```
+    sh "echo -n \"{ \\\"auths\\\": \"  > /home/jenkins/agent/config.json"
+    sh "cat /home/jenkins/agent/.dockercfg >> /home/jenkins/agent/config.json"
+    sh "echo \"}\" >>/home/jenkins/agent/config.json"
+```
+
+ * **maven** container for building a Java application.
+ * **builder** container, using [Kaniko](https://github.com/GoogleContainerTools/kaniko) to build a Docker image without requiring the Docker daemon. Once build, the image is pushed to the internal Openshift registry, using the credentials at `/home/jenkins/agent/config.json`.
+ * **inline-scan** container, where the pipeline executes the `inline-scan.sh` script to analyze the image pushed to the internal Openshift registry, using the credentials from /home/jenkins/agent/config.json.
+
+See [Jenkins examples README.md](../README.md) for common usage tips and troubleshooting.

--- a/jenkins/jenkins-scan-from-repo/Jenkinsfile
+++ b/jenkins/jenkins-scan-from-repo/Jenkinsfile
@@ -2,29 +2,29 @@ pipeline {
     agent {
         kubernetes {
             yaml """
-apiVersion: v1 
-kind: Pod 
-metadata: 
+apiVersion: v1
+kind: Pod
+metadata:
     name: inline-scan-worker
-spec: 
-    containers: 
+spec:
+    containers:
       - name: jnlp
       - name: inline-scan
-        image: sysdiglabs/secure-inline-scan:2
+        image: quay.io/sysdig/secure-inline-scan:2
         command: ['cat']
         tty: true
 """
        }
    }
 
-    parameters { 
-        string(name: 'IMAGE_NAME', defaultValue: 'sysdiglabs/dummy-vuln-app', description: 'Name of the image to be built andscanned (e.g.: myrepo/dummy-app)') 
+    parameters {
+        string(name: 'IMAGE_NAME', defaultValue: 'sysdiglabs/dummy-vuln-app', description: 'Name of the image to be built andscanned (e.g.: myrepo/dummy-app)')
     }
-    
+
     environment {
         SECURE_API_KEY = credentials('sysdig-secure-api-credentials')
     }
-    
+
     stages {
         stage('Scanning Image pulled from repository') {
             steps {

--- a/jenkins/jenkins-scan-from-repo/README.md
+++ b/jenkins/jenkins-scan-from-repo/README.md
@@ -1,0 +1,9 @@
+# Build, push and scan from Openshift internal registry
+
+This minimalistic e[example pipeline](Jenkinsfile) shows how to execute the inline-scan container as part of a podTemplate.
+
+The podTemplate in the example is composed by 2 containers:
+ * **jnlp** container. Required for the Jenkins agent.
+ * **inline-scan** container, where the pipeline executes the `inline-scan.sh` script to analyze the image from the registry.
+
+See [Jenkins examples README.md](../README.md) for common usage tips and troubleshooting.

--- a/tekton/README.md
+++ b/tekton/README.md
@@ -204,8 +204,10 @@ kubectl port-forward svc/tekton-dashboard -n tekton-pipelines 9097:9097
 
 ## References
 
-* [Sysdig Inline Scan](https://github.com/sysdiglabs/secure-inline-scan), _code repository_ and _direct project documentation_. This is the main source of truth for Sysdig inline scanning.
-* [Inline Scanning](https://docs.sysdig.com/en/integrate-with-ci-cd-tools.html#UUID-8945ddee-8c45-58b4-7d85-e06c4235d03c_UUID-5d107c7b-457e-3862-51b5-01bdd9699105), _Sysdig Documentation Hub_.
+* [Sysdig Documentation website - Image Scanning](https://docs.sysdig.com/en/image-scanning.html)
+* [Image Scanning - Integrate with CI/CD Tools](https://docs.sysdig.com/en/integrate-with-ci-cd-tools.html)
 * [Securing Tekton pipelines in OpenShift with Sysdig](https://sysdig.com/blog/securing-tekton-pipelines-openshift/), _blogpost_.
   ⚠**Deprecated information**.
+
+
 


### PR DESCRIPTION
Complete Jenkins documentation with a README.md per example, and including some common troubleshooting.

Also, fixed links to the V1 secure-inline-scan repository (deprecated) and references to Docker hub image (now in quay.io).